### PR TITLE
Handle relative paths for INCLUDE directives

### DIFF
--- a/weblorg.el
+++ b/weblorg.el
@@ -82,6 +82,7 @@
 ;;; Code:
 
 (require 'org)
+(require 'ox-org)
 (require 'ox-html)
 (require 'seq)
 (require 'em-glob)
@@ -939,7 +940,10 @@ can be found in the ROUTE."
 (defun weblorg--parse-org-file (input-path)
   "Parse an Org-Mode file located at INPUT-PATH."
   (let* ((input-data (with-temp-buffer
+                       ;; do an org-to-org export here to handle includes??
                        (insert-file-contents input-path)
+                       (set-visited-file-name input-path t t)
+                       (org-export-to-buffer 'org (buffer-name))
                        (buffer-string)))
          (keywords (weblorg--parse-org input-data))
          (slug

--- a/weblorg.el
+++ b/weblorg.el
@@ -82,7 +82,6 @@
 ;;; Code:
 
 (require 'org)
-(require 'ox-org)
 (require 'ox-html)
 (require 'seq)
 (require 'em-glob)
@@ -961,7 +960,6 @@ An assoc will be returned with all the file properties collected
 from the file, like TITLE, OPTIONS etc.  The generated HTML will
 be added ad an entry to the returned assoc.  Optionally, provide
 an INPUT-PATH to resolve relative links and INCLUDES from."
-  (message "input-path: %s" input-path)
   (let (html keywords)
     ;; Replace the HTML generation code to prevent ox-html from adding
     ;; headers and stuff around the HTML generated for the `body` tag.

--- a/weblorg.el
+++ b/weblorg.el
@@ -364,7 +364,6 @@ Parameters in ~OPTIONS~:
           (name (weblorg--get opt :name "static"))
           (url (weblorg--get opt :url "/static/{{ file }}"))
           (base-dir (weblorg--get opt :base-dir default-directory))
-          (data-dir (weblorg--get opt :data-dir nil))
           (site (or (weblorg--get opt :site)
                     (weblorg-site :base-url weblorg-default-url)))
           ;; The default theme of the site is the defacto "default"
@@ -373,7 +372,6 @@ Parameters in ~OPTIONS~:
      (puthash :site site route)
      (puthash :url url route)
      (puthash :base-dir base-dir route)
-     (puthash :data-dir data-dir route)
      (puthash :theme theme route)
      (puthash :theme-dir "static/" route)
      (puthash :input-pattern (weblorg--get opt :input-pattern "**/*") route)
@@ -407,33 +405,31 @@ Parameters in ~OPTIONS~:
 
 (defun weblorg-export-assets (route)
   "Export static assets ROUTE."
-  (dolist (path (if (gethash :data-dir route) (list (gethash :data-dir route)) (reverse (weblorg--path route "static"))))
-    (progn
-      (message "Processing static path: %s" path)
-      (dolist (file (condition-case nil
-                        (weblorg--find-source-files
-                         (gethash :name route)
-                         path
-                         (gethash :input-pattern route)
-                         (gethash :input-exclude route))
-                      ;; ignore signaling of no-files-matched
-                      (weblorg-error-config nil)))
-        (let* ((relative-path
-                (replace-regexp-in-string
-                 (regexp-quote path) "" file t t))
-               (rendered-output
-                (templatel-render-string
-                 (gethash :output route) `(("file" . ,relative-path))))
-               (dest-file
-                (expand-file-name
-                 rendered-output (gethash :base-dir route))))
-          (weblorg--log-info  "copying: %s -> %s" file dest-file)
-          (mkdir (file-name-directory dest-file) t)
-          (condition-case exc
-              (copy-file file dest-file t)
-            (error
-             (if (not (string= (caddr exc) "Success"))
-                 (message "error: %s: %s" (car (cddr exc)) (cadr (cddr exc)))))))))))
+  (dolist (path (reverse (weblorg--path route "static")))
+    (dolist (file (condition-case nil
+                      (weblorg--find-source-files
+                       (gethash :name route)
+                       path
+                       (gethash :input-pattern route)
+                       (gethash :input-exclude route))
+                    ;; ignore signaling of no-files-matched
+                    (weblorg-error-config nil)))
+      (let* ((relative-path
+              (replace-regexp-in-string
+               (regexp-quote path) "" file t t))
+             (rendered-output
+              (templatel-render-string
+               (gethash :output route) `(("file" . ,relative-path))))
+             (dest-file
+              (expand-file-name
+               rendered-output (gethash :base-dir route))))
+        (weblorg--log-info  "copying: %s -> %s" file dest-file)
+        (mkdir (file-name-directory dest-file) t)
+        (condition-case exc
+            (copy-file file dest-file t)
+          (error
+           (if (not (string= (caddr exc) "Success"))
+               (message "error: %s: %s" (car (cddr exc)) (cadr (cddr exc))))))))))
 
 
 


### PR DESCRIPTION
weblorg--parse-org now starts off by performing an org-to-org export
which resolves all relative paths in INCLUDE directives

Resolves #26 