### PR TITLE
Remove file extension from file-slug

### DIFF
--- a/t/weblorg-tests.el
+++ b/t/weblorg-tests.el
@@ -73,7 +73,7 @@
             (equal
              (weblorg--get-cdr (weblorg--parse-org-file (tests-fixture "bug27/a_funny+file~name.with.many=chars.org"))
                                "file_slug")
-             "a-funny-file-name-with-many-chars-org")))
+             "a-funny-file-name-with-many-chars")))
 
 
 (ert-deftest weblorg--bug26-export-org-with-right-include-path ()

--- a/weblorg.el
+++ b/weblorg.el
@@ -970,7 +970,7 @@ can be found in the ROUTE."
 
 (defun weblorg--parse-org-file (input-path)
   "Parse an Org-Mode file located at INPUT-PATH."
-  (let* ((file-slug (weblorg--slugify (file-name-nondirectory input-path)))
+  (let* ((file-slug (weblorg--slugify (file-name-sans-extension (file-name-nondirectory input-path))))
          (input-data (with-temp-buffer
                        (insert-file-contents input-path)
                        (buffer-string)))


### PR DESCRIPTION
This prevent output file names like `my-post-org.html` instead `my-post.html`.

See #27 