### PR TITLE
Update example with companion docker image usage

### DIFF
--- a/examples/simpleblog/Makefile
+++ b/examples/simpleblog/Makefile
@@ -1,0 +1,10 @@
+.PHONY: dev
+dev:
+	@docker run \
+		-it \
+		-v $(shell pwd -P):/workspace \
+		-v $(shell readlink -f ../../):/opt/weblorg \
+		-p 8000:80 \
+		--rm \
+		--name weblorg \
+		nanzhong/weblorg

--- a/examples/simpleblog/publish.el
+++ b/examples/simpleblog/publish.el
@@ -20,8 +20,10 @@
 
 ;; Install and configure dependencies
 (use-package templatel :ensure t)
-(use-package htmlize)
-(setq org-html-htmlize-output-type 'css)
+(use-package htmlize
+  :ensure t
+  :config
+  (setq org-html-htmlize-output-type 'css))
 
 (require 'weblorg)
 

--- a/examples/simpleblog/publish.el
+++ b/examples/simpleblog/publish.el
@@ -9,6 +9,9 @@
 
 ;; Guarantee the freshest version of the weblorg
 (add-to-list 'load-path "../../")
+;; Also support loading weblorg form /opt/weblorg. This is for use with the nanzhong/weblorg image.
+;; See the volume mount in the Makefile for more context.
+(add-to-list 'load-path "/opt/weblorg")
 
 ;; Setup package management
 (require 'package)


### PR DESCRIPTION
This follows from https://github.com/emacs-love/weblorg/issues/31.

I've cleaned up my container based workflow for weblorg and pushed it to https://github.com/nanzhong/weblorg-docker. It's very much in a proof of concept state, but if this is something people find useful, I'm happy to donate this to the emacs-love org. Depending on the use case some of the file watching logic could be rewritten and supported directly in weblorg, or weblorg could support incremental builds of only what needs to be rebuilt and this tooling could be used to drive the notification/rebuild loop.

This updates the simpleblog example with a Makefile with a phony `dev` target to demonstrate how it could be used. I'm not sure if there's a better way to demonstrate the use case.