### PR TITLE
Make weblorg-export function interactive

### DIFF
--- a/weblorg.el
+++ b/weblorg.el
@@ -391,6 +391,7 @@ Parameters in ~OPTIONS~:
      route)))
 
 (defun weblorg-export ()
+  (interactive)
   "Export all sites."
   (weblorg--with-error
    (maphash


### PR DESCRIPTION
By making `weblorg-export` interactive it is no longer required to leave Emacs while publishing blog.