### PR TITLE
Update weblorg-input-aggregate-by-category to handle filetags as a list

### DIFF
--- a/weblorg.el
+++ b/weblorg.el
@@ -512,11 +512,7 @@ the posts."
   (let (output
         (ht (make-hash-table :test 'equal)))
     (dolist (post posts)
-      (dolist (tag (or (seq-filter
-                        (lambda(x) (not (equal x "")))
-                        (split-string
-                         (or (cdr (assoc "filetags" post)) "") ":"))
-                       '("none")))
+      (dolist (tag (assoc "filetags" post))
         ;; Append post to the list under each tag
         (puthash (downcase tag)
                  (cons post (gethash (downcase tag) ht))


### PR DESCRIPTION
Complement changes on 8d1cdd918308df1a310088650c1a714337892990.