### PR TITLE
require advice in weblorg.el

### DIFF
--- a/weblorg.el
+++ b/weblorg.el
@@ -84,6 +84,7 @@
 (require 'org)
 (require 'ox-html)
 (require 'seq)
+(require 'advice)
 (require 'em-glob)
 (require 'templatel)
 


### PR DESCRIPTION
Requiring advice is needed to make `(ad-unadvice ...)` call working