### PR TITLE
fix: undefer org headline nodes for org 9.7

### DIFF
--- a/weblorg.el
+++ b/weblorg.el
@@ -1017,6 +1017,12 @@ can be found in the ROUTE."
     (weblorg--prepend keywords (cons "file_slug" file-slug))
     keywords))
 
+(defun weblorg--org-element-properties-resolve (node)
+  (if (version<= "9.7-pre" org-version)
+      (with-no-warnings
+        (org-element-properties-resolve node t))
+    node))
+
 (defun weblorg--parse-org (input-data &optional input-path)
   "Parse INPUT-DATA as an Org-Mode file & generate its HTML.
 
@@ -1045,6 +1051,7 @@ an INPUT-PATH to resolve relative links and INCLUDES from."
      (lambda(fn headline contents info)
        ;; Don't override existing value, so users can still put
        ;; whatever they want
+       (setf headline (weblorg--org-element-properties-resolve headline))
        (unless (org-element-property :CUSTOM_ID headline)
          (let ((headline-slug (weblorg--slugify (org-element-property :raw-value headline))))
            (org-element-put-property headline :CUSTOM_ID headline-slug)))
@@ -1078,8 +1085,9 @@ template filter to display a nicely formatted string.
 
 If it's a filetag field, it will return a collection of strings.
 The user will have to iterate over the collection to get all keywords."
-  (let ((key (downcase (org-element-property :key keyword)))
-        (value (org-element-property :value keyword)))
+  (let* ((keyword (weblorg--org-element-properties-resolve keyword))
+         (key (downcase (org-element-property :key keyword)))
+         (value (org-element-property :value keyword)))
     (cons
      key
      (cond ((string= key "date")


### PR DESCRIPTION
The unreleased 9.7 version of org-mode introduced a change that breaks the current `weblorg-slugify` implementation. The change results in some org nodes being deferred and requiring the org buffer to be live when lazily evaluated. (See https://git.savannah.gnu.org/cgit/emacs/org-mode.git/tree/etc/ORG-NEWS#n148).

This change in behaviour results in errors such as:
```
Error: wrong-type-argument (stringp [org-element-deferred org-element--headline-raw-value (4 29) nil])
  mapbacktrace(#f(compiled-function (evald func args flags) #<bytecode -0x1dd916894512f81>))
  debug-early-backtrace()
  debug-early(error (wrong-type-argument stringp [org-element-deferred org-element--headline-raw-value (4 29) nil]))
  replace-regexp-in-string("[^[:alnum:]]" "-" [org-element-deferred org-element--headline-raw-value (4 29) nil])
  #f(compiled-function (accum item) #<bytecode -0x14baae06cc0870c3>)([org-element-deferred org-element--headline-raw-value (4 29) nil] ("[^[:alnum:]]" . "-"))
  #f(compiled-function (elt) #<bytecode 0x190baab04a068801>)(("[^[:alnum:]]" . "-"))
  mapc(#f(compiled-function (elt) #<bytecode 0x190baab04a068801>) (("[^[:alnum:]]" . "-") ("--+" . "-") ("^-" . "") ("-$" . "")))
  seq-do(#f(compiled-function (elt) #<bytecode 0x190baab04a068801>) (("[^[:alnum:]]" . "-") ("--+" . "-") ("^-" . "") ("-$" . "")))
  seq-reduce(#f(compiled-function (accum item) #<bytecode -0x14baae06cc0870c3>) (("[^[:alnum:]]" . "-") ("--+" . "-") ("^-" . "") ("-$" . "")) [org-element-deferred org-element--headline-raw-value (4 29) nil])
  weblorg--slugify([org-element-deferred org-element--headline-raw-value (4 29) nil])
```

This PR makes use of the updated support in `org-element-property` to forced undeferring. Once 9.7 is released, this would be good to revisit (whether that means bumping the required org version or keeping this conditional).