### PR TITLE
Fix #41 weblorg-export warning in interactive mode

### DIFF
--- a/weblorg.el
+++ b/weblorg.el
@@ -1061,6 +1061,7 @@ an INPUT-PATH to resolve relative links and INCLUDES from."
     (with-temp-buffer
       (insert input-data)
       (if input-path (set-visited-file-name input-path t t))
+      (set-buffer-modified-p nil)
       (setq html (org-export-as 'html nil nil t)))
     ;; Uninstall advices
     (ad-unadvise 'org-html-keyword)


### PR DESCRIPTION
By replacing with-temp-buffer with with-temp-file in weblorg--parse-org the warning when closing buffer/file in interactive mode is gone.

I tested it locally, and it doesn't seem to break anything.

@clarete @nanzhong can you please review before merging?