### PR TITLE
update cmc.pub to cleberg.net

### DIFF
--- a/README.org
+++ b/README.org
@@ -22,5 +22,5 @@
    * https://emacs.love/weblorg
    * https://emacs.love/templatel
    * https://clarete.li and https://clarete.li/blog
-   * https://cmc.pub
+   * https://cleberg.net
    * https://marko.euptera.com


### PR DESCRIPTION
Apologies for the quick change from https://github.com/emacs-love/weblorg/pull/81, but cmc.pub was getting caught in spam filters/zscaler/etc., so I reverted to cleberg.net, which is my long-standing domain.

Thanks!